### PR TITLE
Add multi line text input and drawing input

### DIFF
--- a/icons/draw.svg
+++ b/icons/draw.svg
@@ -1,0 +1,5 @@
+<svg height="55px" width="55px" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x="15" y="15" rx="3" ry="3" width="25" height="5" fill="#black"/>
+  <polygon points="15,17.5 10,15 10,20" fill="black"/>
+  <polygon points="10,17.5 7,17.5 10,15" fill="black"/>
+</svg>


### PR DESCRIPTION
Relevant to issue #17 

The code is not working properly and there are still issues with transmiting the drawing and text to the shared activity instance.

As you can see in the commits, I used a custom gtk.TextView to replace the gtk Entry for the input field. One problem I faced was that, if I understand correctly, the sugar's gtk-widgets.css doesn't style textview in a similar way as entry. Would you suggest I manage the css for textview in the source code of chat's activity? 

Also, currently when a user sends messages consecutively, they all bundle up in the same box. I was thinking that giving each separate message its own box, would look better. What do you think?

@chimosky @sourabhaa