### PR TITLE
Port Chat Activity from GTK3 to GTK4

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -18,7 +18,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 import gi
-gi.require_version('Gtk', '3.0')
+gi.require_version('Gtk', '4.0')
 gi.require_version('TelepathyGLib', '0.12')
 
 from gi.repository import Gtk
@@ -32,29 +32,45 @@ from gi.repository import Gst
 
 OSK_HEIGHT = [400, 300]
 SLASH = '-x-SLASH-x-'  # slash safe encoding
-
 import logging
 import json
 import os
 import time
 import dbus
+import re
 from gettext import gettext as _
 
-from sugar3.graphics import style
-from sugar3.graphics.icon import EventIcon, Icon
-from sugar3.graphics.alert import NotifyAlert
-from sugar3.graphics.toolbarbox import ToolbarBox
-from sugar3.graphics.toolbutton import ToolButton
-from sugar3.activity import activity
-from sugar3.activity.activity import get_bundle_path
-from sugar3.presence import presenceservice
-from sugar3.activity.widgets import ActivityToolbarButton
-from sugar3.activity.widgets import StopButton
-from sugar3.activity.activity import get_activity_root
-from sugar3.activity.activity import show_object_in_journal
-from sugar3.datastore import datastore
-from sugar3 import profile
-from sugar3.graphics import iconentry
+def _get_screen_width():
+    display = Gdk.Display.get_default()
+    if display:
+        monitors = display.get_monitors()
+        if monitors and monitors.get_n_items() > 0:
+            return monitors.get_item(0).get_geometry().width
+    return 1200
+
+def _get_screen_height():
+    display = Gdk.Display.get_default()
+    if display:
+        monitors = display.get_monitors()
+        if monitors and monitors.get_n_items() > 0:
+            return monitors.get_item(0).get_geometry().height
+    return 900
+
+from sugar4.graphics import style
+from sugar4.graphics.icon import EventIcon, Icon
+from sugar4.graphics.alert import NotifyAlert
+from sugar4.graphics.toolbarbox import ToolbarBox
+from sugar4.graphics.toolbutton import ToolButton
+from sugar4.activity import activity
+from sugar4.activity.activity import get_bundle_path
+from sugar4.presence import presenceservice
+from sugar4.activity.widgets import ActivityToolbarButton
+from sugar4.activity.widgets import StopButton
+from sugar4.activity.activity import get_activity_root
+from sugar4.activity.activity import show_object_in_journal
+from sugar4.datastore import datastore
+from sugar4 import profile
+from sugar4.graphics import iconentry
 
 from chat import smilies
 from chat.box import ChatBox
@@ -92,44 +108,45 @@ class Chat(activity.Activity):
         self._activity_toolbar_button = ActivityToolbarButton(self)
         self._activity_toolbar_button.connect('clicked', self._fixed_resize_cb)
 
-        toolbar_box.toolbar.insert(self._activity_toolbar_button, 0)
+        toolbar_box.toolbar.prepend(self._activity_toolbar_button)
         self._activity_toolbar_button.show()
 
         self.search_entry = iconentry.IconEntry()
-        self.search_entry.set_size_request(Gdk.Screen.width() / 3, -1)
+        self.search_entry.set_size_request(int(_get_screen_width() / 3), -1)
         self.search_entry.set_icon_from_name(
             iconentry.ICON_ENTRY_PRIMARY, 'entry-search')
         self.search_entry.add_clear_button()
         self.search_entry.connect('activate', self._search_entry_activate_cb)
         self.search_entry.connect('changed', self._search_entry_activate_cb)
 
-        self.connect('key-press-event', self._search_entry_key_press_cb)
+        self.key_ctrl = Gtk.EventControllerKey.new()
+        self.key_ctrl.connect("key-pressed", self._window_key_press_cb)
+        self.add_controller(self.key_ctrl)
 
-        self._search_item = Gtk.ToolItem()
-        self._search_item.add(self.search_entry)
-        toolbar_box.toolbar.insert(self._search_item, -1)
+        self._search_item = Gtk.Box()
+        self._search_item.append(self.search_entry)
+        toolbar_box.toolbar.append(self._search_item)
 
         self._search_prev = ToolButton('go-previous-paired')
         self._search_prev.set_tooltip(_('Previous'))
         self._search_prev.props.accelerator = "<Shift><Ctrl>g"
         self._search_prev.connect('clicked', self._search_prev_cb)
         self._search_prev.props.sensitive = False
-        toolbar_box.toolbar.insert(self._search_prev, -1)
+        toolbar_box.toolbar.append(self._search_prev)
 
         self._search_next = ToolButton('go-next-paired')
         self._search_next.set_tooltip(_('Next'))
         self._search_next.props.accelerator = "<Ctrl>g"
         self._search_next.connect('clicked', self._search_next_cb)
         self._search_next.props.sensitive = False
-        toolbar_box.toolbar.insert(self._search_next, -1)
+        toolbar_box.toolbar.append(self._search_next)
 
-        separator = Gtk.SeparatorToolItem()
-        separator.props.draw = False
-        separator.set_expand(True)
-        toolbar_box.toolbar.insert(separator, -1)
+        separator = Gtk.Box()
+        separator.set_hexpand(True)
+        toolbar_box.toolbar.append(separator)
 
-        toolbar_box.toolbar.insert(StopButton(self), -1)
-        toolbar_box.show_all()
+        toolbar_box.toolbar.append(StopButton(self))
+        toolbar_box.show()
 
         # Chat is room or one to one:
         self._chat_is_room = False
@@ -147,7 +164,7 @@ class Chat(activity.Activity):
                 # we have already joined
                 self._joined_cb(self)
         elif handle.uri:
-            # XMPP non-sugar3 incoming chat, not sharable
+            # XMPP non-sugar4 incoming chat, not sharable
             self._activity_toolbar_button.props.page.share.props.visible = \
                 False
             self._one_to_one_connection(handle.uri)
@@ -164,14 +181,21 @@ class Chat(activity.Activity):
                     _('Please wait for a connection before starting to chat.')
             self.connect('shared', self._shared_cb)
 
-    def _search_entry_key_press_cb(self, activity, event):
-        keyname = Gdk.keyval_name(event.keyval).lower()
+    def _window_key_press_cb(self, controller, keyval, keycode, state):
+        keyname = Gdk.keyval_name(keyval).lower()
         if keyname == 'f':
-            if Gdk.ModifierType.CONTROL_MASK & event.state:
+            if Gdk.ModifierType.CONTROL_MASK & state:
                 self.search_entry.grab_focus()
+                return True
         elif keyname == 'escape':
+            if hasattr(self, '_main_stack') and \
+                    self._main_stack.get_visible_child_name() == "smiley_window":
+                self._hide_smiley_window()
+                return True
             self.search_entry.props.text = ''
             self._entry.grab_focus()
+            return True
+        return False
 
     def _search_entry_on_new_message_cb(self, chatbox):
         self._search_entry_activate_cb(self.search_entry)
@@ -190,7 +214,7 @@ class Chat(activity.Activity):
         self.chatbox.set_search_text(entry.props.text)
         self._update_search_buttons()
 
-    def _update_search_buttons(self,):
+    def _update_search_buttons(self):
         if len(self.chatbox.search_text) == 0:
             self._search_prev.props.sensitive = False
             self._search_next.props.sensitive = False
@@ -211,83 +235,102 @@ class Chat(activity.Activity):
             self.chatbox.search('forward')
             self._update_search_buttons()
 
+    def _setup_canvas(self):
+        ''' Create a canvas '''
+        
+        # Setup application CSS once
+        css_provider = Gtk.CssProvider()
+        bg_black = style.COLOR_BLACK.get_html()
+        bg_grey = style.COLOR_TOOLBAR_GREY.get_html()
+        fg_white = style.COLOR_WHITE.get_html()
+        css = (f".smiley-table-black {{ background-color: {bg_black}; }}\n"
+               f".smiley-toolbar-grey {{ background-color: {bg_grey}; color: {fg_white}; }}")
+        css_provider.load_from_data(css.encode('utf-8'))
+        display = Gdk.Display.get_default()
+        if hasattr(Gtk, 'display_add_provider'):
+            Gtk.display_add_provider(display, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+        else:
+            Gtk.StyleContext.add_provider_for_display(
+                display, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+
+        self._vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        self.set_canvas(self._vbox)
+        self._vbox.show()
+
+        self._make_entry_widgets()
+
+        self.chatbox.set_vexpand(True)
+        self.chatbox.set_hexpand(True)
+
+        # Create a Gtk.Stack to swap between chatbox and smiley window
+        self._main_stack = Gtk.Stack()
+        self._main_stack.set_vexpand(True)
+        self._main_stack.set_hexpand(True)
+        self._main_stack.add_named(self.chatbox, "chatbox")
+        
+        self._vbox.append(self._main_stack)
+        self.chatbox.show()
+        self._main_stack.show()
+
+        self._vbox.append(self._entry_grid)
+        self._entry_grid.show()
+
+        display = Gdk.Display.get_default()
+        if display:
+            display.get_monitors().connect('items-changed', self._configure_cb)
+        self.connect('notify::default-width', self._configure_cb)
+
+    def _configure_cb(self, *args):
+        # *args silently absorbs the (model, position, removed, added) from items-changed
+        self._entry_height = style.GRID_CELL_SIZE
+        entry_width = int(_get_screen_width() - 2 * (self._entry_height + style.GRID_CELL_SIZE))
+        self._entry.set_size_request(entry_width, self._entry_height)
+        self._entry_grid.set_size_request(int(_get_screen_width() - 2 * style.GRID_CELL_SIZE), self._entry_height)
+
+        self._chat_width = int(_get_screen_width())
+        self._chat_height = int(_get_screen_height() - (self._entry_height + 2 * style.GRID_CELL_SIZE))
+
+        self.chatbox.resize_all()
+
+        self._fixed_resize_cb()
+
     def _fixed_resize_cb(self, widget=None, rect=None):
         ''' If a toolbar opens or closes, we need to resize the vbox
-        holding out scrolling window. '''
+        holding our scrolling window. '''
         if self._has_alert:
             dy = style.GRID_CELL_SIZE
         else:
             dy = 0
 
         if self._toolbar_expanded():
-            self.chatbox.set_size_request(
-                self._chat_width,
-                self._chat_height - style.GRID_CELL_SIZE - dy)
-            self._fixed.move(self._entry_grid, style.GRID_CELL_SIZE,
-                             self._chat_height - style.GRID_CELL_SIZE - dy)
-        else:
-            self.chatbox.set_size_request(self._chat_width,
-                                          self._chat_height - dy)
-            self._fixed.move(self._entry_grid, style.GRID_CELL_SIZE,
-                             self._chat_height - dy)
+            dy += style.GRID_CELL_SIZE
+
+        if hasattr(self, '_chat_width') and hasattr(self, '_chat_height'):
+            self.chatbox.set_size_request(self._chat_width, self._chat_height - dy)
 
         self.chatbox.resize_conversation(dy)
 
-    def _setup_canvas(self):
-        ''' Create a canvas '''
-        self._fixed = Gtk.Fixed()
-        self._fixed.set_size_request(
-            Gdk.Screen.width(), Gdk.Screen.height() - style.GRID_CELL_SIZE)
-        self._fixed.connect('size-allocate', self._fixed_resize_cb)
-        self.set_canvas(self._fixed)
-        self._fixed.show()
-
-        self._entry_widgets = self._make_entry_widgets()
-        self._fixed.put(self.chatbox, 0, 0)
-        self.chatbox.show()
-
-        self._fixed.put(self._entry_grid, style.GRID_CELL_SIZE,
-                        self._chat_height)
-        self._entry_grid.show()
-
-        Gdk.Screen.get_default().connect('size-changed', self._configure_cb)
-
-    def _configure_cb(self, event):
-        self._fixed.set_size_request(
-            Gdk.Screen.width(), Gdk.Screen.height() - style.GRID_CELL_SIZE)
-        self._entry_height = style.GRID_CELL_SIZE
-        entry_width = Gdk.Screen.width() - \
-            2 * (self._entry_height + style.GRID_CELL_SIZE)
-        self._entry.set_size_request(entry_width, self._entry_height)
-        self._entry_grid.set_size_request(
-            Gdk.Screen.width() - 2 * style.GRID_CELL_SIZE,
-            self._entry_height)
-
-        self._chat_height = Gdk.Screen.height() - self._entry_height - \
-            style.GRID_CELL_SIZE
-        self._chat_width = Gdk.Screen.width()
-        self.chatbox.set_size_request(self._chat_width, self._chat_height)
-        self.chatbox.resize_all()
-
-        width = int(Gdk.Screen.width() - 2 * style.GRID_CELL_SIZE)
-        height = int(Gdk.Screen.height() - 5 * style.GRID_CELL_SIZE)
-        self._smiley_table.set_size_request(width, height)
-        self._smiley_toolbar.set_size_request(width, -1)
-        self._smiley_window.set_size_request(width, -1)
-
-        self._fixed_resize_cb()
+    def _toolbar_expanded(self):
+        if hasattr(self, '_activity_toolbar_button') and self._activity_toolbar_button.is_expanded():
+            return True
+        return False
 
     def _create_smiley_table(self, width):
-        pixel_size = (style.STANDARD_ICON_SIZE + style.LARGE_ICON_SIZE) / 2
+        # Calculate the exact size so the emojis scale correctly with the Sugar theme
+        pixel_size = int((style.STANDARD_ICON_SIZE + style.LARGE_ICON_SIZE) / 2)
         spacing = style.DEFAULT_SPACING
         button_size = pixel_size + spacing
-        smilies_columns = int(width / button_size)
-        pad = (width - smilies_columns * button_size) / 2
+        smilies_columns = max(1, int(width / button_size))
 
         table = Gtk.Grid()
         table.set_row_spacing(spacing)
         table.set_column_spacing(spacing)
-        table.set_border_width(pad)
+        
+        # Center the grid block so columns don't stretch and create huge gaps!
+        table.set_halign(Gtk.Align.CENTER)
+        
+        table.set_margin_top(spacing)
+        table.set_margin_bottom(spacing)
 
         queue = []
 
@@ -297,15 +340,55 @@ class Chat(activity.Activity):
             except IndexError:
                 self.unbusy()
                 return False
-            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(path,
-                                                            pixel_size,
-                                                            pixel_size)
-            image = Gtk.Image.new_from_pixbuf(pixbuf)
-            box = Gtk.EventBox()
-            box.add(image)
-            box.connect('button-press-event', self._add_smiley_to_entry, code)
+
+            # Load at double resolution (128x128) to ensure sharpness on high-DPI screens.
+            # CRITICAL: Older SVGs lack a viewBox, causing modern librsvg to refuse to scale them.
+            # We must dynamically inject a viewBox based on the width/height to force scaling!
+            with open(path, 'rb') as f:
+                svg_data = f.read().decode('utf-8', errors='ignore')
+                
+            if 'viewBox' not in svg_data:
+                w_match = re.search(r'(?i)width="([0-9.]+)[a-z]*"', svg_data)
+                h_match = re.search(r'(?i)height="([0-9.]+)[a-z]*"', svg_data)
+                if w_match and h_match:
+                    w = w_match.group(1)
+                    h = h_match.group(1)
+                    svg_data = svg_data.replace('<svg', f'<svg viewBox="0 0 {w} {h}"', 1)
+            
+            loader = GdkPixbuf.PixbufLoader.new_with_type('svg')
+            loader.set_size(pixel_size * 2, pixel_size * 2)
+            loader.write(svg_data.encode('utf-8'))
+            loader.close()
+            pixbuf = loader.get_pixbuf()
+            
+            if hasattr(Gdk, 'MemoryTexture') and hasattr(GLib, 'Bytes'):
+                has_alpha = pixbuf.get_has_alpha()
+                format = Gdk.MemoryFormat.R8G8B8A8 if has_alpha else Gdk.MemoryFormat.R8G8B8
+                bytes_data = GLib.Bytes.new(pixbuf.get_pixels())
+                texture = Gdk.MemoryTexture.new(
+                    pixbuf.get_width(),
+                    pixbuf.get_height(),
+                    format,
+                    bytes_data,
+                    pixbuf.get_rowstride()
+                )
+            else:
+                texture = Gdk.Texture.new_for_pixbuf(pixbuf)
+            del pixbuf # Free pixbuf memory early
+            
+            # Gtk.Picture allows us to display the large texture safely scaled down into logical pixels
+            picture = Gtk.Picture.new_for_paintable(texture)
+            picture.set_size_request(pixel_size, pixel_size)
+            picture.set_can_shrink(True)
+            
+            box = Gtk.Box()
+            box.append(picture)
+            gesture = Gtk.GestureClick.new()
+            # Properly bind box and code to the lambda to avoid closure scope leaks
+            gesture.connect('pressed', lambda g, n, dx, dy, b=box, c=code: self._add_smiley_to_entry(b, c))
+            box.add_controller(gesture)
             table.attach(box, x, y, 1, 1)
-            box.show_all()
+            box.show()
             return True
 
         x = 0
@@ -324,7 +407,44 @@ class Chat(activity.Activity):
         GLib.idle_add(_create_smiley_icon_idle_cb)
         return table
 
-    def _add_smiley_to_entry(self, icon, event, text):
+    def _create_smiley_window(self):
+        self._smiley_window = Gtk.Grid()
+
+        # Indent the entire window to create white margins on the sides
+        margin = style.GRID_CELL_SIZE
+        width = int((_get_screen_width()) - 2 * margin)
+        self._smiley_window.set_margin_start(margin)
+        self._smiley_window.set_margin_end(margin)
+
+        self._smiley_toolbar = SmileyToolbar(self)
+        self._smiley_toolbar.set_hexpand(True)
+        self._smiley_window.attach(self._smiley_toolbar, 0, 0, 1, 1)
+        self._smiley_toolbar.show()
+
+        self._smiley_table = Gtk.ScrolledWindow()
+        self._smiley_table.add_css_class("smiley-table-black")
+        
+        # Force the vertical scrollbar to be permanently visible
+        self._smiley_table.set_policy(Gtk.PolicyType.NEVER,
+                                      Gtk.PolicyType.ALWAYS)
+        
+        # Disable overlay scrolling so the scrollbar is permanently visible
+        self._smiley_table.set_overlay_scrolling(False)
+        
+        self._smiley_table.set_vexpand(True)
+        self._smiley_table.set_hexpand(True)
+
+        table = self._create_smiley_table(width)
+        self._smiley_table.set_child(table)
+        self._smiley_window.attach(self._smiley_table, 0, 1, 1, 1)
+        self._smiley_table.show()
+        table.show()
+
+        self._smiley_window.show()
+        
+        self._main_stack.add_named(self._smiley_window, "smiley_window")
+
+    def _add_smiley_to_entry(self, icon, text):
         pos = self._entry.props.cursor_position
         self._entry.insert_text(text, pos)
         self._entry.grab_focus()
@@ -335,7 +455,7 @@ class Chat(activity.Activity):
         self._setup()
 
     def _one_to_one_connection(self, tp_channel):
-        '''Handle a private invite from a non-sugar3 XMPP client.'''
+        '''Handle a private invite from a non-sugar4 XMPP client.'''
         if self.shared_activity or self.text_channel:
             return
         bus_name, connection, channel = json.loads(tp_channel)
@@ -358,6 +478,7 @@ class Chat(activity.Activity):
         text_channel[TelepathyGLib.IFACE_CHANNEL_INTERFACE_GROUP] = \
             dbus.Interface(
                 text_proxy, TelepathyGLib.IFACE_CHANNEL_INTERFACE_GROUP)
+
         self.text_channel = TextChannelWrapper(text_channel, conn)
         self.text_channel.set_received_callback(self._received_cb)
         self.text_channel.handle_pending_messages()
@@ -428,10 +549,6 @@ class Chat(activity.Activity):
         if not self.has_focus:
             self.notify_user(_('Message from %s') % buddy, text)
 
-    def _toolbar_expanded(self):
-        if self._activity_toolbar_button.is_expanded():
-            return True
-        return False
 
     def _alert(self, title, text=None):
         alert = NotifyAlert(timeout=5)
@@ -519,44 +636,45 @@ class Chat(activity.Activity):
         ---------------------------------------
         '''
         self._entry_height = style.GRID_CELL_SIZE
-        entry_width = Gdk.Screen.width() - \
-            2 * (self._entry_height + style.GRID_CELL_SIZE)
-        self._chat_height = Gdk.Screen.height() - self._entry_height - \
-            style.GRID_CELL_SIZE
-        self._chat_width = Gdk.Screen.width()
-
-        self.chatbox.set_size_request(self._chat_width, self._chat_height)
+        entry_width = int((_get_screen_width()) - \
+            2 * (self._entry_height + style.GRID_CELL_SIZE))
 
         self._entry_grid = Gtk.Grid()
         self._entry_grid.set_size_request(
-            Gdk.Screen.width() - 2 * style.GRID_CELL_SIZE,
+            int((_get_screen_width()) - 2 * style.GRID_CELL_SIZE),
             self._entry_height)
 
         self.smiley_button = EventIcon(icon_name='smilies',
                                   pixel_size=self._entry_height)
-        self.smiley_button.connect('button-press-event', self._smiley_button_cb)
+        self.smiley_gesture = Gtk.GestureClick.new()
+        self.smiley_gesture.connect('pressed', lambda g, n, x, y: self._smiley_button_cb(self.smiley_button))
+        self.smiley_button.add_controller(self.smiley_gesture)
         self._entry_grid.attach(self.smiley_button, 0, 0, 1, 1)
         self.smiley_button.show()
 
         self._entry = Gtk.Entry()
         self._entry.set_size_request(entry_width, self._entry_height)
-        self._entry.modify_bg(Gtk.StateType.INSENSITIVE,
-                              style.COLOR_WHITE.get_gdk_color())
-        self._entry.modify_base(Gtk.StateType.INSENSITIVE,
-                                style.COLOR_WHITE.get_gdk_color())
 
         self._entry.props.placeholder_text = \
             _('You must be connected to a friend before starting to chat.')
-        self._entry.connect('focus-in-event', self._entry_focus_in_cb)
-        self._entry.connect('focus-out-event', self._entry_focus_out_cb)
+        self.focus_ctrl = Gtk.EventControllerFocus.new()
+        self.focus_ctrl.connect("enter", lambda c: self._entry_focus_in_cb(self._entry))
+        self.focus_ctrl.connect("leave", lambda c: self._entry_focus_out_cb(self._entry))
+        self._entry.add_controller(self.focus_ctrl)
         self._entry.connect('activate', self._entry_activate_cb)
-        self._entry.connect('key-press-event', self._entry_key_press_cb)
+        
+        self.key_ctrl2 = Gtk.EventControllerKey.new()
+        self.key_ctrl2.connect("key-pressed", self._entry_key_press_cb)
+        self._entry.add_controller(self.key_ctrl2)
+        
         self._entry_grid.attach(self._entry, 1, 0, 1, 1)
         self._entry.show()
 
         self.send_button = EventIcon(icon_name='send',
                                 pixel_size=self._entry_height)
-        self.send_button.connect('button-press-event', self._send_button_cb)
+        self.send_gesture = Gtk.GestureClick.new()
+        self.send_gesture.connect('pressed', lambda g, n, x, y: self._send_button_cb(self.send_button))
+        self.send_button.add_controller(self.send_gesture)
         self._entry_grid.attach(self.send_button, 2, 0, 1, 1)
         self.send_button.show()
 
@@ -565,50 +683,45 @@ class Chat(activity.Activity):
             self.smiley_button.set_sensitive(False)
             self.send_button.set_sensitive(False)
 
-    def _clear_icon_cb(self, entry, icon_pos, event):
+        self._chat_width = int(_get_screen_width())
+        self._chat_height = int(_get_screen_height() - \
+            (self._entry_height + 2 * style.GRID_CELL_SIZE))
+        self.chatbox.set_size_request(self._chat_width, self._chat_height)
+
+    def _clear_icon_cb(self, entry, icon_pos):
         self._entry.set_text("")
 
-    def _get_icon_pixbuf(self, name):
-        icon_theme = Gtk.IconTheme.get_default()
-        icon_info = icon_theme.lookup_icon(
-            name, style.LARGE_ICON_SIZE, 0)
-        pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(
-            icon_info.get_filename(), style.LARGE_ICON_SIZE,
-            style.LARGE_ICON_SIZE)
-        del icon_info
-        return pixbuf
-
-    def _entry_focus_in_cb(self, entry, event):
+    def _entry_focus_in_cb(self, entry):
         self._hide_smiley_window()
 
-    def _entry_focus_out_cb(self, entry, event):
+    def _entry_focus_out_cb(self, entry):
         pass
 
-    def _entry_key_press_cb(self, widget, event):
+    def _entry_key_press_cb(self, controller, keyval, keycode, state):
         '''Check for scrolling keys.
 
         Check if the user pressed Page Up, Page Down, Home or End and
         scroll the window according the pressed key.
         '''
         vadj = self.chatbox.get_vadjustment()
-        if event.keyval == Gdk.KEY_Page_Down:
+        if keyval == Gdk.KEY_Page_Down:
             value = vadj.get_value() + vadj.page_size
             if value > vadj.upper - vadj.page_size:
                 value = vadj.upper - vadj.page_size
             vadj.set_value(value)
-        elif event.keyval == Gdk.KEY_Page_Up:
+        elif keyval == Gdk.KEY_Page_Up:
             vadj.set_value(vadj.get_value() - vadj.page_size)
-        elif event.keyval == Gdk.KEY_Home and \
-                event.get_state() & Gdk.ModifierType.CONTROL_MASK:
+        elif keyval == Gdk.KEY_Home and \
+                state & Gdk.ModifierType.CONTROL_MASK:
             vadj.set_value(vadj.lower)
-        elif event.keyval == Gdk.KEY_End and \
-                event.get_state() & Gdk.ModifierType.CONTROL_MASK:
+        elif keyval == Gdk.KEY_End and \
+                state & Gdk.ModifierType.CONTROL_MASK:
             vadj.set_value(vadj.upper - vadj.page_size)
 
-    def _smiley_button_cb(self, widget, event):
+    def _smiley_button_cb(self, widget):
         self._show_smiley_window()
 
-    def _send_button_cb(self, widget, event):
+    def _send_button_cb(self, widget):
         self._entry_activate_cb(self._entry)
 
     def _entry_activate_cb(self, entry):
@@ -672,59 +785,16 @@ class Chat(activity.Activity):
         self.element.set_property('uri', 'file://%s' % SOUNDS[event])
         self.element.set_state(Gst.State.PLAYING)
 
-    def _create_smiley_window(self):
-        grid = Gtk.Grid()
-        width = int(Gdk.Screen.width() - 2 * style.GRID_CELL_SIZE)
-
-        self._smiley_toolbar = SmileyToolbar(self)
-        height = style.GRID_CELL_SIZE
-        self._smiley_toolbar.set_size_request(width, height)
-        grid.attach(self._smiley_toolbar, 0, 0, 1, 1)
-        self._smiley_toolbar.show()
-
-        self._smiley_table = Gtk.ScrolledWindow()
-        self._smiley_table.set_policy(Gtk.PolicyType.NEVER,
-                                      Gtk.PolicyType.AUTOMATIC)
-        self._smiley_table.modify_bg(
-            Gtk.StateType.NORMAL, style.COLOR_BLACK.get_gdk_color())
-        height = int(Gdk.Screen.height() - 4 * style.GRID_CELL_SIZE)
-        self._smiley_table.set_size_request(width, height)
-
-        table = self._create_smiley_table(width)
-        self._smiley_table.add_with_viewport(table)
-        table.show_all()
-
-        grid.attach(self._smiley_table, 0, 1, 1, 1)
-        self._smiley_table.show()
-
-        self._smiley_window = Gtk.ScrolledWindow()
-        self._smiley_window.set_policy(Gtk.PolicyType.NEVER,
-                                       Gtk.PolicyType.NEVER)
-        self._smiley_window.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
-        self._smiley_window.set_size_request(width, -1)
-
-        self._smiley_window.add_with_viewport(grid)
-
-        def _key_press_event_cb(widget, event):
-            if event.keyval == Gdk.KEY_Escape:
-                self._hide_smiley_window()
-                return True
-            return False
-        self.connect('key-press-event', _key_press_event_cb)
-
-        grid.show()
-
-        self._fixed.put(self._smiley_window, style.GRID_CELL_SIZE, 0)
 
     def _show_smiley_window(self):
         if not hasattr(self, '_smiley_window'):
             self.busy()
             self._create_smiley_window()
-        self._smiley_window.show()
+        self._main_stack.set_visible_child_name("smiley_window")
 
     def _hide_smiley_window(self):
         if hasattr(self, '_smiley_window'):
-            self._smiley_window.hide()
+            self._main_stack.set_visible_child_name("chatbox")
 
 
 class TextChannelWrapper(object):
@@ -815,7 +885,7 @@ class TextChannelWrapper(object):
                 nick = self._conn[co].RequestAliases([sender])[0]
                 buddy = {'nick': nick, 'color': '#000000,#808080'}
             else:
-                # Normal sugar3 MUC chat
+                # Normal sugar4 MUC chat
                 # XXX: cache these
                 buddy = self._get_buddy(sender)
             self._activity_cb(buddy, text)
@@ -862,10 +932,11 @@ class TextChannelWrapper(object):
             tp_name, tp_path, handle)
 
 
-class SmileyToolbar(Gtk.Toolbar):
+class SmileyToolbar(Gtk.Box):
 
     def __init__(self, activity):
-        Gtk.Toolbar.__init__(self)
+        Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL)
+        self.add_css_class("smiley-toolbar-grey")
 
         self._activity = activity
         self._add_separator()
@@ -875,7 +946,7 @@ class SmileyToolbar(Gtk.Toolbar):
 
         self._add_separator()
 
-        self._title = Gtk.Label(_('Insert a smiley'))
+        self._title = Gtk.Label(label=_('Insert a smiley'))
         self._add_widget(self._title)
 
         self._add_separator(True)
@@ -883,28 +954,20 @@ class SmileyToolbar(Gtk.Toolbar):
         self.cancel_button = ToolButton('dialog-cancel')
         self.cancel_button.set_tooltip(_('Cancel'))
         self.cancel_button.connect('clicked', self.__cancel_button_clicked_cb)
-        self.insert(self.cancel_button, -1)
-        self.cancel_button.show()
+        self.append(self.cancel_button)
 
     def _add_separator(self, expand=False):
-        separator = Gtk.SeparatorToolItem()
-        separator.props.draw = False
+        separator = Gtk.Box()
         if expand:
-            separator.set_expand(True)
+            separator.set_hexpand(True)
         else:
             separator.set_size_request(style.DEFAULT_SPACING, -1)
-        self.insert(separator, -1)
-        separator.show()
+        self.append(separator)
 
     def _add_widget(self, widget, expand=False):
-        tool_item = Gtk.ToolItem()
-        tool_item.set_expand(expand)
-
-        tool_item.add(widget)
-        widget.show()
-
-        self.insert(tool_item, -1)
-        tool_item.show()
+        if expand:
+            widget.set_hexpand(True)
+        self.append(widget)
 
     def __cancel_button_clicked_cb(self, widget, data=None):
         self._activity._hide_smiley_window()

--- a/chat/box.py
+++ b/chat/box.py
@@ -29,13 +29,40 @@ from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf
 from gi.repository import Pango
+from gi.repository import GLib
 
-from sugar3.graphics import style
-from sugar3.graphics.palette import Palette, Invoker
-from sugar3.graphics.palettemenu import PaletteMenuItem
-from sugar3.graphics.palette import MouseSpeedDetector
-from sugar3.util import timestamp_to_elapsed_string
-from sugar3 import profile
+import weakref
+
+_TEXTURE_CACHE = weakref.WeakKeyDictionary()
+_CSS_PROVIDER_CACHE = {}
+_HEX_COLOR_RE = re.compile(r'^#[0-9a-fA-F]{6}$')
+
+def _get_screen_width():
+    display = Gdk.Display.get_default()
+    if not display:
+        return 1200
+    monitors = display.get_monitors()
+    if monitors.get_n_items() == 0:
+        return 1200
+    return monitors.get_item(0).get_geometry().width
+
+def _get_screen_height():
+    display = Gdk.Display.get_default()
+    if not display:
+        return 900
+    monitors = display.get_monitors()
+    if monitors.get_n_items() == 0:
+        return 900
+    return monitors.get_item(0).get_geometry().height
+
+
+
+from sugar4.graphics import style
+from sugar4.graphics.palette import Palette, Invoker
+from sugar4.graphics.palettemenu import PaletteMenuItem
+from sugar4.graphics.palette import MouseSpeedDetector
+from sugar4.util import timestamp_to_elapsed_string
+from sugar4 import profile
 
 from chat import smilies
 from chat.roundbox import RoundBox
@@ -80,8 +107,6 @@ class TextBox(Gtk.TextView):
     __gsignals__ = {
         'open-on-journal': (GObject.SignalFlags.RUN_FIRST, None, ([str])), }
 
-    hand_cursor = Gdk.Cursor.new(Gdk.CursorType.HAND2)
-
     def __init__(self, parent,
                  name_color, text_color, bg_color, highlight_color,
                  lang_rtl, nick_name=None, text=None):
@@ -95,7 +120,7 @@ class TextBox(Gtk.TextView):
             'name', foreground=name_color.get_html(), weight=Pango.Weight.BOLD)
         self._fg_tag = self._buffer.create_tag(
             'foreground_color', foreground=text_color.get_html())
-        self._subscript_tag = self.get_buffer().create_tag(
+        self._subscript_tag = self._buffer.create_tag(
             'subscript', foreground=text_color.get_html(),
             rise=-7 * Pango.SCALE)  # in pixels
 
@@ -118,62 +143,109 @@ class TextBox(Gtk.TextView):
         self.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
 
         self.palette = None
+        self._deferred_resize_id = None
+        self.hand_cursor = Gdk.Cursor.new_from_name("pointer", None)
 
         self._mouse_detector = MouseSpeedDetector(200, 5)
         self._mouse_detector.connect('motion-slow', self.__mouse_slow_cb)
 
-        self.modify_bg(0, bg_color.get_gdk_color())
+        highlight_html = highlight_color.get_html()
+        bg_html = bg_color.get_html()
+        
+        # Validate hex colors to prevent CSS injection
+        if not _HEX_COLOR_RE.match(highlight_html): highlight_html = '#888888'
+        if not _HEX_COLOR_RE.match(bg_html): bg_html = '#FFFFFF'
 
-        rgba = Gdk.RGBA()
-        rgba.red, rgba.green, rgba.blue, rgba.alpha = \
-            highlight_color.get_rgba()
-        self.override_background_color(Gtk.StateFlags.SELECTED, rgba)
+        cache_key = (bg_html, highlight_html)
+        css_provider = _CSS_PROVIDER_CACHE.get(cache_key)
+        if css_provider is None:
+            css = ('textview, textview text { background-color: transparent; }'
+                   'textview text selection { background-color: %s; }'
+                   % (highlight_html))
+            css_provider = Gtk.CssProvider()
+            css_provider.load_from_data(css.encode('utf-8'))
+            _CSS_PROVIDER_CACHE[cache_key] = css_provider
 
-        self.add_events(Gdk.EventMask.POINTER_MOTION_MASK |
-                        Gdk.EventMask.BUTTON_PRESS_MASK |
-                        Gdk.EventMask.BUTTON_RELEASE_MASK |
-                        Gdk.EventMask.LEAVE_NOTIFY_MASK)
+        self.get_style_context().add_provider(
+            css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 
-        self.connect('event-after', self.__event_after_cb)
-        self.connect('button-press-event', self.__button_press_cb)
-        self.motion_notify_id = \
-            self.connect('motion-notify-event', self.__motion_notify_cb)
-        self.connect('visibility-notify-event', self.__visibility_notify_cb)
-        self.connect('leave-notify-event', self.__leave_notify_event_cb)
-        self.connect('size-allocate', self.__size_allocate_cb)
+        click_controller = Gtk.GestureClick()
+        click_controller.set_button(0)  # listen to all buttons
+        click_controller.connect('pressed', self.__click_pressed_cb)
+        click_controller.connect('released', self.__click_released_cb)
+        self.add_controller(click_controller)
 
-    def __size_allocate_cb(self, widget, allocation):
+        motion_controller = Gtk.EventControllerMotion()
+        motion_controller.connect('motion', self.__motion_cb)
+        motion_controller.connect('leave', self.__leave_cb)
+        self.add_controller(motion_controller)
+
+    def do_size_allocate(self, width, height, baseline):
         ''' Load buffer after resize to circumvent race condition '''
+        Gtk.TextView.do_size_allocate(self, width, height, baseline)
+        if self._deferred_resize_id is None:
+            self._deferred_resize_id = GLib.idle_add(
+                TextBox._deferred_resize_cb, weakref.ref(self))
+
+    @staticmethod
+    def _deferred_resize_cb(self_ref):
+        self = self_ref()
+        if self is None or not self.get_root():
+            return GLib.SOURCE_REMOVE
+        self._deferred_resize_id = None
         self.set_buffer(self._buffer)
-        self._parent.resize_rb()
+        if hasattr(self, '_parent') and self._parent is not None:
+            self._parent.resize_rb()
+        return GLib.SOURCE_REMOVE
 
     def resize_box(self):
         self.set_buffer(self._empty_buffer)
-        self.set_size_request(Gdk.Screen.width() - style.GRID_CELL_SIZE -
+        self.set_size_request(_get_screen_width() - style.GRID_CELL_SIZE -
                               2 * style.DEFAULT_SPACING, -1)
 
-    def __leave_notify_event_cb(self, widget, event):
+    def __leave_cb(self, controller):
         self._mouse_detector.stop()
 
-    def __button_press_cb(self, widget, event):
-        if event.type == Gdk.EventType.BUTTON_PRESS and event.button == 3:
+    def __click_pressed_cb(self, gesture, n_press, x, y):
+        button = gesture.get_current_button()
+        if button == 2:
+            return  # Ignore middle click for URLs
+            
+        if button == 3:
             # To disable the standard textview popup
-            return True
+            gesture.set_state(Gtk.EventSequenceState.CLAIMED)
+            
+            bx, by = self.window_to_buffer_coords(Gtk.TextWindowType.WIDGET,
+                                                  int(x), int(y))
+            found, iter_tags = self.get_iter_at_location(bx, by)
+
+            if not found:
+                return
+
+            for tag in iter_tags.get_tags():
+                try:
+                    url = tag.url
+                except AttributeError:
+                    url = None
+                if url is not None:
+                    palette = tag.palette
+                    # Pass the click coordinates so the popover positions correctly
+                    palette.set_pointing_to(Gdk.Rectangle(x=int(x), y=int(y), width=8, height=8))
+                    palette.popup()
+                    break
 
     # Links can be activated by clicking.
-    def __event_after_cb(self, widget, event):
-        if event.type.value_name != 'GDK_BUTTON_RELEASE':
-            return False
+    def __click_released_cb(self, gesture, n_press, x, y):
+        button = gesture.get_current_button()
+        if button in (2, 3):
+            return
+            
+        bx, by = self.window_to_buffer_coords(Gtk.TextWindowType.WIDGET,
+                                              int(x), int(y))
+        found, iter_tags = self.get_iter_at_location(bx, by)
 
-        x, y = self.window_to_buffer_coords(Gtk.TextWindowType.WIDGET,
-                                            int(event.x), int(event.y))
-        iter_tags = self.get_iter_at_location(x, y)
-
-        if Gtk.check_version(3, 19, 8) is None:
-            if not iter_tags[0]:
-                return False
-
-            iter_tags = iter_tags[1]
+        if not found:
+            return
 
         for tag in iter_tags.get_tags():
             try:
@@ -181,15 +253,8 @@ class TextBox(Gtk.TextView):
             except AttributeError:
                 url = None
             if url is not None:
-                if event.button == 3:
-                    palette = tag.palette
-                    xw, yw = self.get_toplevel().get_pointer()
-                    palette.popup()
-                else:
-                    self._show_via_journal(url)
+                self._show_via_journal(url)
                 break
-
-        return False
 
     def _show_via_journal(self, url):
         self.emit('open-on-journal', url)
@@ -204,13 +269,10 @@ class TextBox(Gtk.TextView):
             return False
 
         self.palette = None
-        iter_tags = self.get_iter_at_location(x, y)
+        found, iter_tags = self.get_iter_at_location(x, y)
 
-        if Gtk.check_version(3, 19, 8) is None:
-            if not iter_tags[0]:
-                return False
-
-            iter_tags = iter_tags[1]
+        if not found:
+            return False
 
         tags = iter_tags.get_tags()
         for tag in tags:
@@ -228,47 +290,37 @@ class TextBox(Gtk.TextView):
         # and if one of them is a link, change the cursor to the 'hands' cursor
 
         hovering_over_link = self.check_url_hovering(x, y)
-        win = self.get_window(Gtk.TextWindowType.TEXT)
         if hovering_over_link:
-            win.set_cursor(self.hand_cursor)
+            self.set_cursor(self.hand_cursor)
             self._mouse_detector.start()
         else:
-            win.set_cursor(None)
+            self.set_cursor(None)
             self._mouse_detector.stop()
 
     def __mouse_slow_cb(self, widget):
-        x, y = self.get_pointer()
-        hovering_over_link = self.check_url_hovering(x, y)
-        if hovering_over_link:
-            if self.palette is not None:
-                xw, yw = self.get_toplevel().get_pointer()
-                self.palette.popup()
-                self._mouse_detector.stop()
-        else:
-            if self.palette is not None:
-                self.palette.popdown()
+        if hasattr(self, '_last_mouse_x'):
+            hovering_over_link = self.check_url_hovering(
+                self._last_mouse_x, self._last_mouse_y)
+            if hovering_over_link:
+                if self.palette is not None:
+                    # Pass the widget coordinates to ensure correct positioning
+                    self.palette.set_pointing_to(Gdk.Rectangle(
+                        x=self._last_widget_x, y=self._last_widget_y, width=8, height=8))
+                    self.palette.popup()
+                    self._mouse_detector.stop()
+            else:
+                if self.palette is not None:
+                    self.palette.popdown()
 
     # Update the cursor image if the pointer moved.
-    def __motion_notify_cb(self, widget, event):
-        x, y = self.window_to_buffer_coords(Gtk.TextWindowType.WIDGET,
-                                            int(event.x), int(event.y))
-        self.set_cursor_if_appropriate(x, y)
-        self.get_pointer()
-        return False
-
-    def __visibility_notify_cb(self, widget, event):
-        # Also update the cursor image if the window becomes visible
-        # (e.g. when a window covering it got iconified).
-        bx, by = self.window_to_buffer_coords(
-            Gtk.TextWindowType.WIDGET, 200, 200)
+    def __motion_cb(self, controller, x, y):
+        bx, by = self.window_to_buffer_coords(Gtk.TextWindowType.WIDGET,
+                                              int(x), int(y))
+        self._last_mouse_x = bx
+        self._last_mouse_y = by
+        self._last_widget_x = int(x)
+        self._last_widget_y = int(y)
         self.set_cursor_if_appropriate(bx, by)
-        return False
-
-    def __palette_mouse_enter_cb(self, widget, event):
-        self.handler_block(self.motion_notify_id)
-
-    def __palette_mouse_leave_cb(self, widget, event):
-        self.handler_unblock(self.motion_notify_id)
 
     def _add_name(self, name):
         buf = self._buffer
@@ -308,7 +360,13 @@ class TextBox(Gtk.TextView):
                 for i in smilies.parse(word):
                     if isinstance(i, GdkPixbuf.Pixbuf):
                         start = self.iter_text.get_offset()
-                        buf.insert_pixbuf(self.iter_text, i)
+                        
+                        texture = _TEXTURE_CACHE.get(i)
+                        if texture is None:
+                            texture = Gdk.Texture.new_for_pixbuf(i)
+                            _TEXTURE_CACHE[i] = texture
+                            
+                        buf.insert_paintable(self.iter_text, texture)
                         buf.apply_tag(self._subscript_tag,
                                       buf.get_iter_at_offset(start),
                                       self.iter_text)
@@ -325,7 +383,6 @@ class TextBox(Gtk.TextView):
 class ChatBox(Gtk.ScrolledWindow):
 
     __gsignals__ = {
-        'foo': (GObject.SignalFlags.RUN_FIRST, None, ([])),
         'open-on-journal': (GObject.SignalFlags.RUN_FIRST, None, ([str])),
         'new-message': (GObject.SignalFlags.RUN_FIRST, None, ([]))
     }
@@ -352,9 +409,12 @@ class ChatBox(Gtk.ScrolledWindow):
 
         self._conversation = Gtk.Grid()
         self._conversation.set_row_spacing(style.DEFAULT_PADDING)
-        self._conversation.set_border_width(0)
+        self._conversation.set_margin_start(0)
+        self._conversation.set_margin_end(0)
+        self._conversation.set_margin_top(0)
+        self._conversation.set_margin_bottom(0)
         self._conversation.set_size_request(
-            Gdk.Screen.width() - style.GRID_CELL_SIZE, -1)
+            _get_screen_width() - style.GRID_CELL_SIZE, -1)
 
         self.search_text = ''
 
@@ -364,21 +424,18 @@ class ChatBox(Gtk.ScrolledWindow):
         # OSK padding for conversation
         self._dy = 0
 
-        evbox = Gtk.EventBox()
-        evbox.modify_bg(
-            Gtk.StateType.NORMAL, style.COLOR_WHITE.get_gdk_color())
-        evbox.add(self._conversation)
-        self._conversation.show()
+        evbox = Gtk.Box()
+        evbox.set_hexpand(True)
+        evbox.add_css_class("view")
+
+        evbox.append(self._conversation)
 
         self.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.ALWAYS)
-        self.add_with_viewport(evbox)
-        evbox.show()
+        self.set_child(evbox)
 
         vadj = self.get_vadjustment()
         vadj.connect('changed', self._scroll_changed_cb)
         vadj.connect('value-changed', self._scroll_value_changed_cb)
-
-        self.connect('foo', self.resize_rb)
 
     def set_search_text(self, text):
         self.search_text = text
@@ -564,7 +621,7 @@ class ChatBox(Gtk.ScrolledWindow):
         return self._chat_log
 
     def add_text(self, buddy, text, status_message=False):
-        '''Display text on screen, with name and colors.
+        r'''Display text on screen, with name and colors.
         buddy -- buddy object or dict {nick: string, color: string}
         (The dict is for loading the chat log from the journal,
         when we don't have the buddy object any more.)
@@ -679,9 +736,13 @@ class ChatBox(Gtk.ScrolledWindow):
 
             grid_internal = Gtk.Grid()
             grid_internal.set_row_spacing(0)
-            grid_internal.set_border_width(style.DEFAULT_PADDING)
+            grid_internal.set_hexpand(True)
+            grid_internal.set_margin_start(style.DEFAULT_PADDING)
+            grid_internal.set_margin_end(style.DEFAULT_PADDING)
+            grid_internal.set_margin_top(style.DEFAULT_PADDING)
+            grid_internal.set_margin_bottom(style.DEFAULT_PADDING)
             grid_internal.set_size_request(
-                Gdk.Screen.width() - style.GRID_CELL_SIZE, -1)
+                _get_screen_width() - style.GRID_CELL_SIZE, -1)
             self._grid_list.append(grid_internal)
 
             row = 0
@@ -700,27 +761,24 @@ class ChatBox(Gtk.ScrolledWindow):
             self._last_msg = message
 
             grid_internal.attach(message, 0, row, 1, 1)
-            row += 1
 
-            align = Gtk.Alignment.new(xalign=0.0, yalign=0.0, xscale=1.0,
-                                      yscale=1.0)
+            align_box = Gtk.Box()
+            align_box.set_hexpand(True)
+            align_box.set_valign(Gtk.Align.START)
             if rb.tail is None:
                 bottom_padding = style.zoom(7)
             else:
                 bottom_padding = style.zoom(35)
-            align.set_padding(style.zoom(7), bottom_padding, style.zoom(30),
-                              style.zoom(30))
-
-            align.add(grid_internal)
-            grid_internal.show()
-
-            rb.pack_start(align, True, True, 0)
-            align.show()
-
+            align_box.set_margin_top(style.zoom(7))
+            align_box.set_margin_bottom(bottom_padding)
+            align_box.set_margin_start(style.zoom(30))
+            align_box.set_margin_end(style.zoom(30))
+            
+            align_box.append(grid_internal)
+            rb.append(align_box)
+            
             self._conversation.attach(rb, 0, self._row_counter, 1, 1)
-            rb.show()
             self._row_counter += 1
-            message.show()
 
         if status_message:
             self._last_msg_sender = None
@@ -745,15 +803,12 @@ class ChatBox(Gtk.ScrolledWindow):
                           style.COLOR_WHITE, style.COLOR_BUTTON_GREY, False,
                           None, timestamp_to_elapsed_string(timestamp_seconds))
         self._message_list.append(message)
-        box = Gtk.HBox()
-        align = Gtk.Alignment.new(
-            xalign=0.5, yalign=0.0, xscale=0.0, yscale=0.0)
-        box.pack_start(align, True, True, 0)
-        align.show()
-        align.add(message)
-        message.show()
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        message.set_halign(Gtk.Align.CENTER)
+        message.set_valign(Gtk.Align.START)
+        message.set_hexpand(False)
+        box.append(message)
         self._conversation.attach(box, 0, self._row_counter, 1, 1)
-        box.show()
         self._row_counter += 1
         self.add_log_timestamp(timestamp)
         self._last_msg_sender = None
@@ -809,10 +864,10 @@ class ChatBox(Gtk.ScrolledWindow):
     def resize_rb(self):
         for grid in self._grid_list:
             grid.set_size_request(
-                Gdk.Screen.width() - style.GRID_CELL_SIZE, -1)
+                _get_screen_width() - style.GRID_CELL_SIZE, -1)
         for rb in self._rb_list:
             rb.set_size_request(
-                Gdk.Screen.width() - style.GRID_CELL_SIZE, -1)
+                _get_screen_width() - style.GRID_CELL_SIZE, -1)
         self.resize_conversation()
 
     def resize_conversation(self, dy=None):
@@ -822,9 +877,9 @@ class ChatBox(Gtk.ScrolledWindow):
         else:
             self._dy = dy
 
+        self._conversation.set_margin_bottom(dy)
         self._conversation.set_size_request(
-            Gdk.Screen.width() - style.GRID_CELL_SIZE,
-            Gdk.Screen.height() - 2 * style.GRID_CELL_SIZE - dy)
+            _get_screen_width() - style.GRID_CELL_SIZE, -1)
 
 
 class ContentInvoker(Invoker):
@@ -843,17 +898,19 @@ class _URLMenu(Palette):
 
     def __init__(self, url):
         Palette.__init__(self, url)
-        self.owns_clipboard = False
         self.url = self._url_check_protocol(url)
 
-        menu_box = Gtk.VBox()
-        self.set_content(menu_box)
-        menu_box.show()
-        self._content.set_border_width(1)
+        menu_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        menu_box.set_margin_start(1)
+        menu_box.set_margin_end(1)
+        menu_box.set_margin_top(1)
+        menu_box.set_margin_bottom(1)
+        
         menu_item = PaletteMenuItem(_('Copy to Clipboard'), 'edit-copy')
         menu_item.connect('activate', self._copy_to_clipboard_cb)
-        menu_box.pack_start(menu_item, False, False, 0)
-        menu_item.show()
+        menu_box.append(menu_item)
+        
+        self.set_content(menu_box)
         self.props.invoker = ContentInvoker()
 
     def create_palette(self):
@@ -861,29 +918,8 @@ class _URLMenu(Palette):
 
     def _copy_to_clipboard_cb(self, menuitem):
         logging.debug('Copy %s to clipboard', self.url)
-        clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
-        targets = [('text/uri-list', 0, 0), ('UTF8_STRING', 0, 1)]
-
-        if not clipboard.set_with_data(targets, self._clipboard_data_get_cb,
-                                       self._clipboard_clear_cb, (self.url)):
-            logging.debug('GtkClipboard.set_with_data failed!')
-        else:
-            self.owns_clipboard = True
-
-    def _clipboard_data_get_cb(self, clipboard, selection, info, data):
-        logging.debug('_clipboard_data_get_cb data=%s target=%s', data,
-                      selection.target)
-        if selection.target in ['text/uri-list']:
-            if not selection.set_uris([data]):
-                logging.debug('failed to set_uris')
-        else:
-            logging.debug('not uri')
-            if not selection.set_text(data):
-                logging.debug('failed to set_text')
-
-    def _clipboard_clear_cb(self, clipboard, data):
-        logging.debug('clipboard_clear_cb')
-        self.owns_clipboard = False
+        clipboard = Gdk.Display.get_default().get_clipboard()
+        clipboard.set_text(self.url)
 
     def _url_check_protocol(self, url):
         '''Check that the url has a protocol, otherwise prepend https://

--- a/chat/roundbox.py
+++ b/chat/roundbox.py
@@ -17,39 +17,94 @@
 import math
 
 from gi.repository import Gtk
+from gi.repository import Graphene
+from gi.repository import Gsk
 
-from sugar3.graphics import style
+from sugar4.graphics import style
 
 _BORDER_DEFAULT = style.LINE_WIDTH
 
+_SHARED_PROVIDER = None
 
-class RoundBox(Gtk.HBox):
+
+class RoundBox(Gtk.Box):
     __gtype_name__ = 'RoundBox'
 
     def __init__(self, **kwargs):
-        Gtk.HBox.__init__(self, **kwargs)
+        kwargs.setdefault('orientation', Gtk.Orientation.HORIZONTAL)
+        Gtk.Box.__init__(self, **kwargs)
+        
+        self.add_css_class('roundbox')
+        self.connect('realize', self._on_realize)
+        
         self._radius = style.zoom(15)
-        self.border_color = style.COLOR_BLACK
-        self.tail = None
-        self.background_color = None
-        self.set_resize_mode(Gtk.ResizeMode.PARENT)
-        self.set_reallocate_redraws(True)
-        self.connect('draw', self.__draw_cb)
-        self.connect('add', self.__add_cb)
+        self._border_color = style.COLOR_BLACK
+        self._tail = None
+        self._background_color = None
 
-    def __add_cb(self, child, params):
-        child.set_border_width(style.zoom(5))
+    def _on_realize(self, widget):
+        widget.disconnect_by_func(self._on_realize)
+        
+        global _SHARED_PROVIDER
+        if _SHARED_PROVIDER is None:
+            _SHARED_PROVIDER = Gtk.CssProvider()
+            _SHARED_PROVIDER.load_from_string('.roundbox { background: none; border: none; }')
+            Gtk.StyleContext.add_provider_for_display(
+                self.get_display(),
+                _SHARED_PROVIDER,
+                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            )
 
-    def __draw_cb(self, widget, cr):
-        rect = self.get_allocation()
+    @property
+    def border_color(self): return self._border_color
+    @border_color.setter
+    def border_color(self, v): self._border_color = v; self.queue_draw()
+
+    @property
+    def background_color(self): return self._background_color
+    @background_color.setter
+    def background_color(self, v): self._background_color = v; self.queue_draw()
+
+    @property
+    def tail(self): return self._tail
+    @tail.setter
+    def tail(self, v): self._tail = v; self.queue_draw()
+
+    def append(self, child):
+        # Replicate GTK3 __add_cb border padding
+        padding = style.zoom(5)
+        child.set_margin_start(child.get_margin_start() + padding)
+        child.set_margin_end(child.get_margin_end() + padding)
+        child.set_margin_top(child.get_margin_top() + padding)
+        child.set_margin_bottom(child.get_margin_bottom() + padding)
+        super().append(child)
+
+    def pack_start(self, child, expand, fill, padding):
+        '''GTK3 compat wrapper — just delegates to append.'''
+        self.append(child)
+
+    def add(self, child):
+        '''GTK3 compat wrapper — just delegates to append.'''
+        self.append(child)
+
+    def do_snapshot(self, snapshot):
+        w = self.get_width()
+        h = self.get_height()
+        if w <= 0 or h <= 0:
+            return
+            
+        rect = Graphene.Rect()
+        rect.init(0, 0, w, h)
+        cr = snapshot.append_cairo(rect)
+
         hmargin = style.zoom(15)
         x = hmargin
         y = 0
-        width = rect.width - _BORDER_DEFAULT * 2. - hmargin * 2
+        width = w - _BORDER_DEFAULT * 2. - hmargin * 2
         if self.tail is None:
-            height = rect.height - _BORDER_DEFAULT * 2.
+            height = h - _BORDER_DEFAULT * 2.
         else:
-            height = rect.height - _BORDER_DEFAULT * 2. - self._radius
+            height = h - _BORDER_DEFAULT * 2. - self._radius
 
         cr.move_to(x + self._radius, y)
         cr.arc(x + width - self._radius, y + self._radius,
@@ -81,44 +136,16 @@ class RoundBox(Gtk.HBox):
                math.pi, math.pi * 1.5)
         cr.close_path()
 
-        if self.background_color is not None:
-            r, g, b, __ = self.background_color.get_rgba()
-            cr.set_source_rgb(r, g, b)
+        if self._background_color is not None:
+            r, g, b, a = self._background_color.get_rgba()
+            cr.set_source_rgba(r, g, b, a)
             cr.fill_preserve()
 
-        if self.border_color is not None:
-            r, g, b, __ = self.border_color.get_rgba()
-            cr.set_source_rgb(r, g, b)
+        if self._border_color is not None:
+            r, g, b, a = self._border_color.get_rgba()
+            cr.set_source_rgba(r, g, b, a)
             cr.set_line_width(_BORDER_DEFAULT)
             cr.stroke()
-        return False
 
-
-if __name__ == '__main__':
-
-    win = Gtk.Window()
-    win.connect('destroy', Gtk.main_quit)
-    win.set_default_size(450, 450)
-    vbox = Gtk.VBox()
-
-    box1 = RoundBox()
-    box1.tail = 'right'
-    vbox.add(box1)
-    label1 = Gtk.Label("Test 1")
-    box1.add(label1)
-
-    rbox = RoundBox()
-    rbox.tail = 'left'
-    rbox.background_color = style.Color('#FF0000')
-    vbox.add(rbox)
-    label2 = Gtk.Label("Test 2")
-    rbox.add(label2)
-
-    bbox = RoundBox()
-    bbox.background_color = style.Color('#aaff33')
-    bbox.border_color = style.Color('#ff3300')
-    vbox.add(bbox)
-
-    win.add(vbox)
-    win.show_all()
-    Gtk.main()
+        # Render children on top of the background
+        Gtk.Box.do_snapshot(self, snapshot)

--- a/chat/smilies.py
+++ b/chat/smilies.py
@@ -20,8 +20,8 @@
 import os
 from gettext import gettext as _
 from gi.repository import GdkPixbuf
-from sugar3.graphics import style
-from sugar3.activity.activity import get_bundle_path
+from sugar4.graphics import style
+from sugar4.activity.activity import get_bundle_path
 
 THEME = \
     [

--- a/run_chat.py
+++ b/run_chat.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import sys
+import os
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk, Gdk, Gio
+
+# Set up standalone environment
+os.environ.setdefault("SUGAR_BUNDLE_ID", "org.laptop.Chat")
+os.environ.setdefault("SUGAR_BUNDLE_NAME", "Chat")
+os.environ.setdefault("SUGAR_BUNDLE_PATH", os.getcwd())
+os.environ.setdefault("SUGAR_ACTIVITY_ROOT", os.path.expanduser("~/.sugar/default/org.laptop.Chat"))
+
+activity_root = os.environ["SUGAR_ACTIVITY_ROOT"]
+for subdir in ["tmp", "instance", "data"]:
+    os.makedirs(os.path.join(activity_root, subdir), exist_ok=True)
+
+from sugar4.activity.activityhandle import ActivityHandle
+from activity import Chat
+
+# prevent garbage collection of the window
+_chat_window = None
+
+
+def main():
+    def on_activate(app):
+        global _chat_window
+        icon_theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
+        icon_theme.add_search_path(os.path.join(os.getcwd(), "icons"))
+
+        # Load the CSS Provider if exists
+        css_provider = Gtk.CssProvider()
+        css_path = os.path.join(os.getcwd(), "activity.css")
+        if os.path.exists(css_path):
+            css_provider.load_from_path(css_path)
+            Gtk.StyleContext.add_provider_for_display(
+                Gdk.Display.get_default(),
+                css_provider,
+                Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            )
+
+        handle = ActivityHandle(
+            activity_id="chat-local",
+            object_id="chat-local"
+        )
+        try:
+            _chat_window = Chat(handle)
+            app.add_window(_chat_window)
+            _chat_window.present()
+        except Exception as e:
+            print("Failed to launch activity: %s" % e, file=sys.stderr)
+            import traceback
+            traceback.print_exc()
+            app.quit()
+
+    app = Gtk.Application(
+        application_id="org.laptop.Chat.local",
+        flags=Gio.ApplicationFlags.NON_UNIQUE
+    )
+    app.connect("activate", on_activate)
+    return app.run(sys.argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-from sugar3.activity import bundlebuilder
+from sugar4.activity import bundlebuilder
 
 bundlebuilder.start()


### PR DESCRIPTION
This PR completes the migration of the Sugar Chat Activity from GTK3 to GTK4. The main goal was to update the UI to GTK4 while preserving the existing appearance and behavior as closely as possible. Along the way, several GTK3 APIs that are deprecated or no longer available had to be replaced with their GTK4 equivalents.

#### Rendering (`chat/roundbox.py`)
GTK4 replaces the old `draw` signal with the `do_snapshot` rendering pipeline. The custom `RoundBox` widget has been updated accordingly.
* The speech bubble background is still rendered with Cairo using `snapshot.append_cairo()`, since the bubble shape (particularly the tail) is easier to express that way on current GTK4 releases. Child widgets are rendered normally through `Gtk.Box.do_snapshot()`, giving a hybrid approach that preserves the original visuals.
* Because GTK4 no longer provides the same container padding behavior as GTK3, spacing is now handled by accumulating margins when children are appended.
* GTK4 themes may also apply backgrounds to `Gtk.Box` widgets that interfere with the custom bubble rendering, so a shared CSS provider is installed to remove inherited backgrounds and borders from `RoundBox`.

#### Styling and resource management (`chat/box.py`)
Legacy APIs such as `modify_bg()` and `override_background_color()` have been replaced with CSS-based styling.
* Bubble colors are generated through `Gtk.CssProvider` objects, with a module-level cache to avoid creating duplicate providers for the same colors. Input colors are validated with a hex color regex before generating CSS.
* The embedded `TextView` is explicitly styled with a transparent background so the parent bubble is visible underneath.
* Image insertion now uses `insert_paintable()` with `Gdk.Texture` instead of `insert_pixbuf()`. A `weakref.WeakKeyDictionary` is used to cache textures while allowing them to be released automatically when the corresponding pixbufs are no longer in use.

#### Event handling (`activity.py`, `chat/box.py`)
GTK4 removes `Gtk.EventBox` and several traditional event signals, so interaction code has been migrated to event controllers.
* Click handling now uses `Gtk.GestureClick`.
* Pointer tracking uses `Gtk.EventControllerMotion`.
* Keyboard/focus handling is implemented with `Gtk.EventControllerKey` and `Gtk.EventControllerFocus`.

#### Layout updates (`activity.py`)
Deprecated widgets such as `Gtk.Alignment`, `Gtk.HBox`, `Gtk.VBox`, and `Gtk.Fixed` have been replaced with `Gtk.Box` layouts and standard margin/expansion properties.
* The previous manual visibility switching between the chat area and smiley picker has been replaced with a `Gtk.Stack`.
* For URL popovers, positioning now uses `set_pointing_to()` with an anchor rectangle instead of relying on global window coordinates, which improves compatibility with Wayland.

#### Build and Testing Architecture
* A standalone `run_chat.py` helper has been added to simplify local testing without starting a full Sugar session. It sets up the required mock environment variables and runs the activity in `NON_UNIQUE` application mode so multiple instances can be launched simultaneously.
* The build configuration has also been updated for `sugar4`, and resource paths for the smiley picker have been adjusted to work correctly after the migration.

---

### Testing & Verification

**1. Testing Environment**
* **OS:** Fedora 44 ISO (Sugar Build)
* **Environment:** Oracle VirtualBox
* **Toolkit:** `sugar-toolkit-gtk4`

**2. Isolated UI Verification (Developer Bypass)**

Because a second VM wasn't available to test the Avahi/Telepathy shared network functionality locally, I temporarily bypassed the network lock to verify the GTK4 UI layout and gestures in isolation. 

*Note: The following 4 lines in `activity.py` were temporarily commented out during my local testing to keep the text entry active:*

```python
# if not self.get_shared():
#     self._entry.set_sensitive(False)
#     self.smiley_button.set_sensitive(False)
#     self.send_button.set_sensitive(False)
```

**CRITICAL:** This was strictly a local testing bypass. These lines **have been restored** in the final commit of this PR, preserving the original network locking behavior for the final build.

**3. Interactive Components Verified**
* **Search Integration:** Tested the `<` and `>` navigation buttons; confirmed `Gtk.TextTag` correctly highlights matched words.
* **Emoji Picker:** Verified the `Gtk.Stack` toggles the smiley interface smoothly, and `Gtk.GestureClick` successfully inserts emojis into the text buffer.
* **URL Palettes:** Verified URL detection, hover states, and Wayland-compatible popover menus using `set_pointing_to`.
* **Auto-Scrolling:** Sent consecutive messages to verify `Gtk.Adjustment` correctly snaps the view to the latest message.